### PR TITLE
Update dependencies

### DIFF
--- a/digestive-functors-aeson.cabal
+++ b/digestive-functors-aeson.cabal
@@ -50,7 +50,7 @@ test-suite tests
     aeson,
     base >= 4.5 && < 5,
     bytestring >= 0.9,
-    digestive-functors >= 0.6,
+    digestive-functors >= 0.7,
     HUnit >= 1.2,
     mtl,
     scientific >= 0.2.0.1,

--- a/digestive-functors-aeson.cabal
+++ b/digestive-functors-aeson.cabal
@@ -27,12 +27,12 @@ library
   exposed-modules:
     Text.Digestive.Aeson
   build-depends:
-    aeson >= 0.7 && < 1.5,
+    aeson >= 0.7 && <= 1.5.6.0,
     base >= 4.5 && < 5,
     containers >= 0.5,
     digestive-functors >= 0.7 && < 0.9,
-    lens >= 4.4 && < 4.18,
-    lens-aeson >= 1 && < 1.1,
+    lens >= 4.4 && <= 4.19.2,
+    lens-aeson >= 1 && <= 1.1.1,
     safe >= 0.3.3,
     text >= 0.11,
     vector >= 0.10


### PR DESCRIPTION
Provide support for Aeson 1.5.6.0

- Update `aeson` upper boundary
- Update `lens` upper boundary
- Update `lens-aeson` upper boundary 
- Match lib and test `digestive-functors` versions